### PR TITLE
Add rule to find tables with indexes that have 50+ columns

### DIFF
--- a/rules/X++/OverlyWideTableIndexes.xq
+++ b/rules/X++/OverlyWideTableIndexes.xq
@@ -1,0 +1,24 @@
+(: Find tables with indexes that have 50+ columns. :)
+(: This is not supported in Dynamics 365 for Finance and Operations. :)
+(: @Language Xpp :)
+(: @Author Andreas.Nielsen@microsoft.com :)
+
+<Diagnostics Category='Mandatory' href='docs.microsoft.com/Socratex/OverlyWideTableIndexes' Version='1.0'>
+{
+for $t in /Table
+for $i in $t/Metadata/Indexes/AxTableIndex
+where count($i/Fields/AxTableIndexField) >= 50
+return
+  <Diagnostic>
+    <Moniker>OverlyWideTableIndexes</Moniker>
+    <Severity>Error</Severity>
+    <Path>{string($t/@PathPrefix)}</Path>
+    <Message>Indexes with 50+ columns are not allowed.</Message>
+    <DiagnosticType>AppChecker</DiagnosticType>
+    <Line>{string($t/@StartLine)}</Line>
+    <Column>{string($t/@StartCol)}</Column>
+    <EndLine>{string($t/@EndLine)}</EndLine>
+    <EndColumn>{string($t/@EndCol)}</EndColumn>
+  </Diagnostic>
+}
+</Diagnostics>


### PR DESCRIPTION
Having tables with indexes that contain 50 or more columns is not supported. This rule would assist customers and partners in avoiding to reach this silent cap.