### PR TITLE
Fix for issue #9 - TableIndex rule is throwing an error when the tabl…

### DIFF
--- a/rules/X++/TableIndex.xq
+++ b/rules/X++/TableIndex.xq
@@ -5,7 +5,8 @@
 <Diagnostics Category='Mandatory' href='docs.microsoft.com/Socratex/TableIndex' Version='1.0'>
 {
   for $t in /Table
-  where not (exists ($t//ClusteredIndex))
+  where exists ($t//ClusteredIndex)
+  and $t//ClusteredIndex = ''
   return
     <Diagnostic>
       <Moniker>TableIndex</Moniker>


### PR DESCRIPTION
Fix for issue #9 - TableIndex rule is throwing an error when the table uses SurrogateKey as Clustered Index